### PR TITLE
Changing window.onresize to window.addEventListener('resize', function)

### DIFF
--- a/starfield.js
+++ b/starfield.js
@@ -24,13 +24,13 @@ Starfield.prototype.initialise = function(div) {
 	self.width = window.innerWidth;
 	self.height = window.innerHeight;
 
-	window.onresize = function(event) {
+	window.addEventListener('resize', function resize(event) {
 		self.width = window.innerWidth;
 		self.height = window.innerHeight;
 		self.canvas.width = self.width;
 		self.canvas.height = self.height;
 		self.draw();
- 	}
+	});
 
 	//	Create the canvas.
 	var canvas = document.createElement('canvas');


### PR DESCRIPTION
Its recommended to use addEventListener.
I've also added a name to the anonymous function to make stack traces readable.
